### PR TITLE
Make the GRUB2 Bootloader option visible

### DIFF
--- a/other/kcm_grub2.desktop
+++ b/other/kcm_grub2.desktop
@@ -7,7 +7,7 @@ Exec=kcmshell5 kcm_grub2
 X-KDE-Library=kcm_grub2
 X-KDE-ParentApp=kcontrol
 
-X-KDE-System-Settings-Parent-Category=startup-and-shutdown
+X-KDE-System-Settings-Parent-Category=session
 
 Name=GRUB2 Bootloader
 Name[ast]=Cargador d'arrinque GRUB2


### PR DESCRIPTION
The GRUB2 Bootloader option is visible in KDE Plasma 4 according to a YouTube video, but it doesn't work in KDE Plasma 5 because of broken System Settings category